### PR TITLE
feat(ssl): Log issuer name

### DIFF
--- a/cmd/sslcheck/main.go
+++ b/cmd/sslcheck/main.go
@@ -110,6 +110,7 @@ func sslcheckRun(cmd *cobra.Command, _ []string) error {
 				Time("expiry", status.Expires).
 				Dur("remainingTime", status.TimeRemaining).
 				Int("status", int(status.Status)).
+				Str("issuer", status.Issuer).
 				Msg(fmt.Sprintf("%s - expires in %s", status.CommonName, formatDuration(status.TimeRemaining)))
 		}
 	}

--- a/internal/ssl/ssl.go
+++ b/internal/ssl/ssl.go
@@ -32,6 +32,7 @@ type CertStatus struct {
 	Host          string
 	Expires       time.Time
 	TimeRemaining time.Duration
+	Issuer        string
 }
 
 // Check retrieves the SSL certificate chain for a host and returns a map of
@@ -77,6 +78,7 @@ func Check(log zerolog.Logger, host string, cfg CheckerConfig) (map[string]CertS
 				CommonName:    cert.Subject.CommonName,
 				TimeRemaining: remainingValidity,
 				Expires:       cert.NotAfter,
+				Issuer:        cert.Issuer.CommonName,
 			}
 		}
 	}


### PR DESCRIPTION
I think it would be useful to see the issuer name in-order to determine the appropriate actions for renewal.